### PR TITLE
feat: AOP Based Logging

### DIFF
--- a/src/main/java/com/howaboutquestion/backend/domain/auth/dto/request/TokenUserInfo.java
+++ b/src/main/java/com/howaboutquestion/backend/domain/auth/dto/request/TokenUserInfo.java
@@ -12,6 +12,7 @@ import lombok.*;
  * DATE              AUTHOR             NOTE<br>
  * -----------------------------------------------------------<br>
  * 25.07.17          cod0216           최초 생성 <br>
+ * 25.07.03          cod0216           ID 타입 Long 변경 <br>
  */
 
 @Getter
@@ -19,7 +20,7 @@ import lombok.*;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TokenUserInfo {
-    private Integer id;
+    private Long id;
     private UserType userType;
     private String email;
     private String name;

--- a/src/main/java/com/howaboutquestion/backend/domain/auth/dto/request/UserLoginRequest.java
+++ b/src/main/java/com/howaboutquestion/backend/domain/auth/dto/request/UserLoginRequest.java
@@ -15,9 +15,16 @@ import lombok.ToString;
  * 25.07.13          cod0216           최초 생성 <br>
  */
 @Getter
-@ToString
 public class UserLoginRequest {
     @Email
     private String email;
     private String password;
+
+    @Override
+    public String toString() {
+        return "UserLoginRequest(" +
+                "email='" + email + '\'' +
+                ", password='****" + '\'' +
+                ')';
+    }
 }

--- a/src/main/java/com/howaboutquestion/backend/domain/auth/dto/response/UserLoginResponse.java
+++ b/src/main/java/com/howaboutquestion/backend/domain/auth/dto/response/UserLoginResponse.java
@@ -16,6 +16,7 @@ import lombok.*;
  */
 @Getter
 @Builder
+@ToString
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserLoginResponse {

--- a/src/main/java/com/howaboutquestion/backend/domain/auth/dto/response/UserRegisterResponse.java
+++ b/src/main/java/com/howaboutquestion/backend/domain/auth/dto/response/UserRegisterResponse.java
@@ -19,7 +19,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class UserRegisterResponse {
 
-    private Integer id;
+    private Long id;
     private LocalDateTime createdAt;
     private String email;
     private String name;

--- a/src/main/java/com/howaboutquestion/backend/domain/user/dto/UserDetail.java
+++ b/src/main/java/com/howaboutquestion/backend/domain/user/dto/UserDetail.java
@@ -98,12 +98,12 @@ public class UserDetail implements UserDetails {
     }
 
     /**
-     * 회원 PK 값을 반환합니다.
-     * @return 회원 고유 ID값
+     * 회원 이름을 반환합니다.
+     * @return 회원 이름
      */
     @Override
     public String getUsername() {
-        return user.getId().toString();
+        return user.getName();
     }
 
     /**
@@ -121,4 +121,9 @@ public class UserDetail implements UserDetails {
     public String getUserProfile() {
         return user.getProfile();
     }
+
+    public String getUserId(){
+        return user.getId().toString();
+    }
+
 }

--- a/src/main/java/com/howaboutquestion/backend/domain/user/dto/resopnse/UserInfoResponse.java
+++ b/src/main/java/com/howaboutquestion/backend/domain/user/dto/resopnse/UserInfoResponse.java
@@ -22,7 +22,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserInfoResponse {
-    private Integer id;
+    private Long id;
     private LocalDateTime createdAt;
     private UserType userType;
     private String email;

--- a/src/main/java/com/howaboutquestion/backend/domain/user/dto/resopnse/UserInfoResponse.java
+++ b/src/main/java/com/howaboutquestion/backend/domain/user/dto/resopnse/UserInfoResponse.java
@@ -18,6 +18,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @Builder
+@ToString
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserInfoResponse {

--- a/src/main/java/com/howaboutquestion/backend/global/common/LoggingAspect.java
+++ b/src/main/java/com/howaboutquestion/backend/global/common/LoggingAspect.java
@@ -1,0 +1,126 @@
+package com.howaboutquestion.backend.global.common;
+
+import com.howaboutquestion.backend.domain.user.dto.UserDetail;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.*;
+import org.aspectj.lang.reflect.CodeSignature;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class LoggingAspect {
+    private final HttpServletRequest request;
+
+
+    @Pointcut("execution(* com.howaboutquestion.backend.domain.*.controller.*.*(..))")
+    private void onRequest() {
+    }
+
+    @Pointcut("execution(* com.howaboutquestion.backend.domain.*.service.*.*(..))")
+    private void onService() {
+    }
+
+    @Before("onRequest()")
+    public void beforeRequestLog(JoinPoint joinPoint) {
+        if(!log.isDebugEnabled()){
+            log.info("[Request]-[{}] : HttpMethod: {} Url: {} Args: {}", getUserType(), request.getMethod(), request.getRequestURI(), getParams(joinPoint).toString());
+        }else {
+            log.debug("[Request]-[{}:{}] : HttpMethod: {} Url: {} Args: {} Headers: {}", getUserType(), getUserId(), request.getMethod(), request.getRequestURI(), getParams(joinPoint).toString(), getHeader(request));
+        }
+    }
+
+    @Before("onService()")
+    public void beforeServiceLog(JoinPoint joinPoint) {
+        log.debug("[Before]-[{}:{}] : Method: {} Args: {}", getUserType(), getUserId(), joinPoint.getSignature().toShortString(), getParams(joinPoint));
+    }
+
+    @AfterReturning(value = "onService()", returning = "returnObj")
+    public void afterServiceLog(JoinPoint joinPoint, Object returnObj) {
+        log.debug("[After]-[{}:{}] : Method: {} Return: {}", getUserType(), getUserId(), joinPoint.getSignature().toShortString(), returnObj);
+    }
+
+
+    @AfterReturning(value = "onRequest()", returning = "returnObj")
+    public void afterResponseLog(JoinPoint joinPoint, Object returnObj) {
+        if(!log.isDebugEnabled())
+            log.info("[Response]-[{}] : {}", getUserType(), returnObj);
+    }
+
+    @Around("onRequest()")
+    public Object aroundRequestLog(ProceedingJoinPoint proceed) throws Throwable {
+        long start = System.currentTimeMillis();
+        Object result = proceed.proceed();
+        long duration = System.currentTimeMillis() - start;
+        log.debug("[Response]-[{}:{}] : Method: {} time: {}ms, returned: {} ",
+                getUserType(),
+                getUserId(),
+                proceed.getSignature().toShortString(),
+                duration,
+                result
+        );
+        return result;
+
+    }
+
+    private Map<String, Object> getParams(JoinPoint joinPoint) {
+        CodeSignature codeSignature = (CodeSignature) joinPoint.getSignature();
+        String[] parameterNames = codeSignature.getParameterNames();
+        Object[] args = joinPoint.getArgs();
+        Map<String, Object> params = new HashMap<>();
+        for (int i = 0; i < parameterNames.length; i++) {
+            params.put(parameterNames[i], args[i]);
+        }
+        return params;
+    }
+
+    private String getUserType() {
+        Authentication auth = SecurityContextHolder.getContext() != null ? SecurityContextHolder.getContext().getAuthentication() : null;
+
+        if(Objects.isNull(auth) || !auth.isAuthenticated() || "anonymousUser".equals(auth.getPrincipal()))
+            return "ANONYMOUS";
+
+        return auth.getAuthorities().stream().map(GrantedAuthority::getAuthority)
+                .map(role -> role.startsWith("ROLE_") ? role.substring(5) : role)
+                .sorted()
+                .collect(java.util.stream.Collectors.joining(","));
+    }
+
+    private String getUserId() {
+        Authentication auth = SecurityContextHolder.getContext() != null ? SecurityContextHolder.getContext().getAuthentication() : null;
+
+        if(Objects.isNull(auth) || !auth.isAuthenticated() || "anonymousUser".equals(auth.getPrincipal()))
+            return "X";
+
+        Object principal = auth.getPrincipal();
+        if (principal instanceof UserDetail userDetail) {
+            return String.valueOf(userDetail.getUserId());
+        }
+        return auth.getName();
+    }
+
+    private Map<String, String> getHeader(HttpServletRequest request) {
+        Map<String, String> headers = new HashMap<>();
+        Enumeration<String> headerNames = request.getHeaderNames();
+        while(headerNames.hasMoreElements()) {
+            String name = headerNames.nextElement();
+            headers.put(name, request.getHeader(name));
+        }
+        return headers;
+    }
+}
+
+

--- a/src/main/java/com/howaboutquestion/backend/global/common/LoggingAspect.java
+++ b/src/main/java/com/howaboutquestion/backend/global/common/LoggingAspect.java
@@ -63,9 +63,9 @@ public class LoggingAspect {
     @Before("onRequest()")
     public void beforeRequestLog(JoinPoint joinPoint) {
         if(!log.isDebugEnabled()){
-            log.info("[Request]-[{}] : HttpMethod: {} Url: {} Args: {}", getUserType(), request.getMethod(), request.getRequestURI(), getParams(joinPoint).toString());
+            log.info("\n[Request]-[{}] : HttpMethod: {} Url: {} Args: {}", getUserType(), request.getMethod(), request.getRequestURI(), getParams(joinPoint).toString());
         }else {
-            log.debug("[Request]-[{}:{}] : HttpMethod: {} Url: {} Args: {} Headers: {}", getUserType(), getUserId(), request.getMethod(), request.getRequestURI(), getParams(joinPoint).toString(), getHeader(request));
+            log.debug("\n[Request]-[{}:{}] : HttpMethod: {} Url: {} Args: {} Headers: {}", getUserType(), getUserId(), request.getMethod(), request.getRequestURI(), getParams(joinPoint).toString(), getHeader(request));
         }
     }
 
@@ -75,7 +75,18 @@ public class LoggingAspect {
      */
     @Before("onService()")
     public void beforeServiceLog(JoinPoint joinPoint) {
-        log.debug("[Before]-[{}:{}] : Method: {} Args: {}", getUserType(), getUserId(), joinPoint.getSignature().toShortString(), getParams(joinPoint));
+        log.debug("\n[Before]-[{}:{}] : Method: {} Args: {}", getUserType(), getUserId(), joinPoint.getSignature().toShortString(), getParams(joinPoint));
+    }
+
+    /**
+     * 사용자의 요청에 의해 호출된 메서드가 실행 중 발상한 에러 정보를 로그에 기록합니다.
+     * @param joinPoint 호출된 메서드의 정보를 제공하는 JoinPoint 객체
+     * @param e 에러 정보를 갖는 객체
+     */
+
+    @AfterThrowing(value = "onService()", throwing = "e")
+    public void afterServiceThrowLog(JoinPoint joinPoint, Throwable e){
+        log.error("\n[Error]-[{}:{}] : Method: {} Args: {} Error: {} StackTrace: {}", getUserType(), getUserId(), joinPoint.getSignature().toShortString(), getParams(joinPoint), e.getMessage(), e.getStackTrace());
     }
 
     /**
@@ -85,7 +96,7 @@ public class LoggingAspect {
      */
     @AfterReturning(value = "onService()", returning = "returnObj")
     public void afterServiceLog(JoinPoint joinPoint, Object returnObj) {
-        log.debug("[After]-[{}:{}] : Method: {} Return: {}", getUserType(), getUserId(), joinPoint.getSignature().toShortString(), returnObj);
+        log.debug("\n[After]-[{}:{}] : Method: {} Return: {}", getUserType(), getUserId(), joinPoint.getSignature().toShortString(), returnObj);
     }
 
 
@@ -97,32 +108,46 @@ public class LoggingAspect {
     @AfterReturning(value = "onRequest()", returning = "returnObj")
     public void afterResponseLog(JoinPoint joinPoint, Object returnObj) {
         if(!log.isDebugEnabled())
-            log.info("[Response]-[{}] : {}", getUserType(), returnObj);
+            log.info("\n[Response]-[{}] : {}", getUserType(), returnObj);
     }
 
     /**
-     * 사용자의 요청에대 한 최종 응답 정보들을 반환합니다.
+     * 사용자의 요청에 대한 최종 응답 정보들을 반환합니다.
      * @param proceed 실행 메서드
      * @return 수행한 메서드의 결과 값
-     * @throws Throwable 메서드 수행 중 발생한 예러
+     * @throws Throwable 메서드 수행 중 발생한 에러
      */
     @Around("onRequest()")
     public Object aroundRequestLog(ProceedingJoinPoint proceed) throws Throwable {
         long start = System.currentTimeMillis();
-        Object result = proceed.proceed();
-        long duration = System.currentTimeMillis() - start;
-        log.debug("[Response]-[{}:{}] : Method: {} time: {}ms, returned: {} ",
-                getUserType(),
-                getUserId(),
-                proceed.getSignature().toShortString(),
-                duration,
-                result
-        );
-        return result;
+        Object result = null;
+        try {
+            result = proceed.proceed();
+            long duration = System.currentTimeMillis() - start;
+            log.debug("\n[Response]-[{}:{}] : Method: {} time: {}ms, returned: {} ",
+                    getUserType(),
+                    getUserId(),
+                    proceed.getSignature().toShortString(),
+                    duration,
+                    result
+            );
+            return result;
+        } catch (Throwable e) {
+            long duration = System.currentTimeMillis() - start;
+            log.error("\n[Response]-[{}:{}] : Method: {} time: {}ms Error: {} StackTrace: {}",
+                    getUserType(),
+                    getUserId(),
+                    proceed.getSignature().toShortString(),
+                    duration,
+                    e.getMessage(),
+                    e.getStackTrace()
+            );
+            throw e;
+        }
     }
 
     /**
-     * 메서드의 인자값에과 요청의 파라미터 값을 매핑하여 파마미터 정보를 생성합니다.
+     * 메서드의 인자값과 요청의 파라미터 값을 매핑하여 파마미터 정보를 생성합니다.
      * @param joinPoint 호출된 메서드의 정보를 제공하는 JoinPoint 객체
      * @return 매핑된 파라미터 정보
      */
@@ -161,7 +186,7 @@ public class LoggingAspect {
         Authentication auth = SecurityContextHolder.getContext() != null ? SecurityContextHolder.getContext().getAuthentication() : null;
 
         if(Objects.isNull(auth) || !auth.isAuthenticated() || "anonymousUser".equals(auth.getPrincipal()))
-            return "X";
+            return "XXX";
 
         Object principal = auth.getPrincipal();
         if (principal instanceof UserDetail userDetail) {
@@ -173,7 +198,7 @@ public class LoggingAspect {
     /**
      * 사용자 요청에 포함되어 있는 Header 값들 반환합니다.
      * @param request 사용자 요청
-     * @return 요청에 포함된 Header값
+     * @return 요청에 포함된 Header 값
      */
     private Map<String, String> getHeader(HttpServletRequest request) {
         Map<String, String> headers = new HashMap<>();

--- a/src/main/java/com/howaboutquestion/backend/global/common/LoggingAspect.java
+++ b/src/main/java/com/howaboutquestion/backend/global/common/LoggingAspect.java
@@ -18,6 +18,19 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+
+/**
+ * packageName    : com.howaboutquestion.backend.global.common<br>
+ * fileName       : LoggingAspect.java<br>
+ * author         : cod0216 <br>
+ * date           : 2025.08.03<br>
+ * description    : 요청과 응답 수행 과정을 추적하는 로깅 Aspect 클래스입니다. <br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 25.08.03          cod0216           최초 생성 <br>
+ */
+
 @Slf4j
 @Aspect
 @Component
@@ -26,14 +39,27 @@ public class LoggingAspect {
     private final HttpServletRequest request;
 
 
+    /**
+     * 로그를 적용할 포인트컷을 정의합니다
+     * `com.howaboutquestion.backend.domain.*.controller` 패키지의 모든 메서드 실행 시 적용됩니다.
+     */
     @Pointcut("execution(* com.howaboutquestion.backend.domain.*.controller.*.*(..))")
     private void onRequest() {
     }
 
+    /**
+     * 로그를 적용할 포인트컷을 정의합니다
+     * `com.howaboutquestion.backend.domain.*.service` 패키지의 모든 메서드 실행 시 적용됩니다.
+     */
     @Pointcut("execution(* com.howaboutquestion.backend.domain.*.service.*.*(..))")
     private void onService() {
     }
 
+
+    /**
+     * 사용자의 요청에 대한 정보들을 로그에 기록합니다.
+     * @param joinPoint 호출된 메서드의 정보를 제공하는 JoinPoint 객체
+     */
     @Before("onRequest()")
     public void beforeRequestLog(JoinPoint joinPoint) {
         if(!log.isDebugEnabled()){
@@ -43,23 +69,43 @@ public class LoggingAspect {
         }
     }
 
+    /**
+     * 사용자의 요청에 의해 호출된 메서드가 응답을 반환하기 이전의 상태 정보를 로그에 기록합니다.
+     * @param joinPoint 호출된 메서드의 정보를 제공하는 JoinPoint 객체
+     */
     @Before("onService()")
     public void beforeServiceLog(JoinPoint joinPoint) {
         log.debug("[Before]-[{}:{}] : Method: {} Args: {}", getUserType(), getUserId(), joinPoint.getSignature().toShortString(), getParams(joinPoint));
     }
 
+    /**
+     * 사용자의 요청에 의해 호출된 메서드가 반환하는 정보들을 로그에 기록합니다.
+     * @param joinPoint 호출된 메서드의 정보를 제공하는 JoinPoint 객체
+     * @param returnObj 호출된 메서드의 결과값을 제공하는 returnObj 객체
+     */
     @AfterReturning(value = "onService()", returning = "returnObj")
     public void afterServiceLog(JoinPoint joinPoint, Object returnObj) {
         log.debug("[After]-[{}:{}] : Method: {} Return: {}", getUserType(), getUserId(), joinPoint.getSignature().toShortString(), returnObj);
     }
 
 
+    /**
+     * 사용자의 요청에 의해 반환되는 결과를 로그에 기록합니다.
+     * @param joinPoint 호출된 메서드의 정보를 제공하는 JoinPoint 객체
+     * @param returnObj 호출된 메서드의 결과값을 제공하는 returnObj 객체
+     */
     @AfterReturning(value = "onRequest()", returning = "returnObj")
     public void afterResponseLog(JoinPoint joinPoint, Object returnObj) {
         if(!log.isDebugEnabled())
             log.info("[Response]-[{}] : {}", getUserType(), returnObj);
     }
 
+    /**
+     * 사용자의 요청에대 한 최종 응답 정보들을 반환합니다.
+     * @param proceed 실행 메서드
+     * @return 수행한 메서드의 결과 값
+     * @throws Throwable 메서드 수행 중 발생한 예러
+     */
     @Around("onRequest()")
     public Object aroundRequestLog(ProceedingJoinPoint proceed) throws Throwable {
         long start = System.currentTimeMillis();
@@ -73,9 +119,13 @@ public class LoggingAspect {
                 result
         );
         return result;
-
     }
 
+    /**
+     * 메서드의 인자값에과 요청의 파라미터 값을 매핑하여 파마미터 정보를 생성합니다.
+     * @param joinPoint 호출된 메서드의 정보를 제공하는 JoinPoint 객체
+     * @return 매핑된 파라미터 정보
+     */
     private Map<String, Object> getParams(JoinPoint joinPoint) {
         CodeSignature codeSignature = (CodeSignature) joinPoint.getSignature();
         String[] parameterNames = codeSignature.getParameterNames();
@@ -87,6 +137,10 @@ public class LoggingAspect {
         return params;
     }
 
+    /**
+     * 요청을 보낸 사용자의 UserType을 반환합니다.
+     * @return 사용자의 타입
+     */
     private String getUserType() {
         Authentication auth = SecurityContextHolder.getContext() != null ? SecurityContextHolder.getContext().getAuthentication() : null;
 
@@ -99,6 +153,10 @@ public class LoggingAspect {
                 .collect(java.util.stream.Collectors.joining(","));
     }
 
+    /**
+     * 요청을 보낸 사용자의 Id값을 반환합니다.
+     * @return 사용자의 Id값
+     */
     private String getUserId() {
         Authentication auth = SecurityContextHolder.getContext() != null ? SecurityContextHolder.getContext().getAuthentication() : null;
 
@@ -112,6 +170,11 @@ public class LoggingAspect {
         return auth.getName();
     }
 
+    /**
+     * 사용자 요청에 포함되어 있는 Header 값들 반환합니다.
+     * @param request 사용자 요청
+     * @return 요청에 포함된 Header값
+     */
     private Map<String, String> getHeader(HttpServletRequest request) {
         Map<String, String> headers = new HashMap<>();
         Enumeration<String> headerNames = request.getHeaderNames();

--- a/src/main/java/com/howaboutquestion/backend/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/howaboutquestion/backend/global/filter/JwtAuthenticationFilter.java
@@ -46,11 +46,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final  String BEARER  = "Bearer ";
 
     private static final String[] ALLOW_URLS = new String[] {
-            "/", "/api/auths/login"
+            "/", "/api/auths/register", "/api/auths/login",
     };
 
     private static final String[] NOT_ALLOW_URLS = new String[] {
-            "/", "/api/auths/logout"
+            "/", "/api/auths/logout",
     };
 
 
@@ -93,7 +93,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
      */
     protected void processValidAccessToken(String accessToken){
         UserType type = jwtUtility.getUserType(accessToken);
-        Integer userId = jwtUtility.getUserId(accessToken);
+        Long userId = jwtUtility.getUserId(accessToken);
         String userName = jwtUtility.getUserName(accessToken);
         String userEmail = jwtUtility.getUserEmail(accessToken);
         String userProfile = jwtUtility.getProfile(accessToken);

--- a/src/main/java/com/howaboutquestion/backend/global/response/ResponseDTO.java
+++ b/src/main/java/com/howaboutquestion/backend/global/response/ResponseDTO.java
@@ -4,6 +4,7 @@ import com.howaboutquestion.backend.global.common.StatusCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 
 /**
  * packageName    : com.howaboutquestion.backend.global.common<br>
@@ -20,6 +21,7 @@ import lombok.RequiredArgsConstructor;
  * <br>
  */
 @Getter
+@ToString
 @AllArgsConstructor
 public abstract class ResponseDTO {
     private boolean success;

--- a/src/main/java/com/howaboutquestion/backend/global/response/SuccessResponseDTO.java
+++ b/src/main/java/com/howaboutquestion/backend/global/response/SuccessResponseDTO.java
@@ -3,6 +3,7 @@ package com.howaboutquestion.backend.global.response;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.howaboutquestion.backend.global.common.StatusCode;
 import lombok.Getter;
+import lombok.ToString;
 
 /**
  * packageName    : com.howaboutquestion.backend.global.response<br>
@@ -19,6 +20,7 @@ import lombok.Getter;
  */
 
 @Getter
+@ToString
 @JsonPropertyOrder({"success", "httpCode", "httpStatus", "serverCode", "message", "data"})
 public final class SuccessResponseDTO<T> extends ResponseDTO {
     private final T data;
@@ -45,7 +47,6 @@ public final class SuccessResponseDTO<T> extends ResponseDTO {
     /**
      * 응답 데이터를 커스텀한 메시지와 함께 반환할 Reponse 클래스 생성하고 반환 합니다.
      * @param data 응답 데이터
-     * @param message 커스텀 메시지
      */
     public static <T> SuccessResponseDTO<T> create (T data){
         return new SuccessResponseDTO(data);
@@ -59,9 +60,5 @@ public final class SuccessResponseDTO<T> extends ResponseDTO {
     public static <T> SuccessResponseDTO<T> create (T data, String message){
         return new SuccessResponseDTO(data, message);
     }
-
-
-
-
 
 }

--- a/src/main/java/com/howaboutquestion/backend/global/util/JwtUtility.java
+++ b/src/main/java/com/howaboutquestion/backend/global/util/JwtUtility.java
@@ -64,7 +64,7 @@ public class JwtUtility {
      * @param uuid 토큰 고유 ID
      * @return AccessToken 을 반환합니다.
      */
-    public String createAccessToken(Integer userId, String userEmail, String userName, UserType userType, String profile, String uuid) {
+    public String createAccessToken(Long userId, String userEmail, String userName, UserType userType, String profile, String uuid) {
         return createToken(userId, userEmail, userName, userType, profile, uuid, accessTokenValidateTime * 1000L);
     }
 
@@ -75,7 +75,7 @@ public class JwtUtility {
      * @param uuid 토큰 고유 ID
      * @return RefreshToken 을 반환합니다.
      */
-    public String createRefreshToken(Integer userId, String userEmail, String userName, UserType userType, String profile, String uuid){
+    public String createRefreshToken(Long userId, String userEmail, String userName, UserType userType, String profile, String uuid){
         return createToken(userId, userEmail, userName, userType, profile, uuid, refreshTokenValidateTime * 1000L);
     }
 
@@ -90,7 +90,7 @@ public class JwtUtility {
      * @param validity 유효기간
      * @return jwt 토큰
      */
-    private String createToken(Integer userId, String userEmail, String userName, UserType userType, String profile, String uuid, long validity){
+    private String createToken(Long userId, String userEmail, String userName, UserType userType, String profile, String uuid, long validity){
         Date createTime = new Date();
         Date expireTime = new Date(createTime.getTime() + validity);
 
@@ -112,7 +112,7 @@ public class JwtUtility {
      * @param token Jwt 토큰
      * @return 사용자 Id
      */
-    public Integer getUserId(String token) { return getClaim(token, CLAIM_USER_ID, Integer.class);}
+    public Long getUserId(String token) { return getClaim(token, CLAIM_USER_ID, Long.class);}
 
     /**
      * Jwt 토큰에서 사용자 이메일을 가져옵니다.


### PR DESCRIPTION
<!-- 
제목은 아래와 같은 커밋 규칙을 따르세요: 
- feat: 새로운 기능
- fix: 버그 수정
- docs: 문서 및 주석 수정
- refactor: 코드 리팩토링 (기능 변화 없음)
- style: css 변경 (로직 변화 없음)
- test: 테스트 코드 추가 또는 수정 
- build: 빌드 설정 
- chore: 기타 사소한 변경
-->


## #️⃣ 관련 이슈
<!-- 
관련된 이슈 번호를 링크하거나 언급해주세요.
예: Closes #12, #34
-->
- #8 

## 📝 작업 내용
<!-- 
이번 PR에서 작업한 내용을 항목별로 설명해주세요(이미지 첨부 가능)
예:
- 로그인 API (`POST /api/login`) 추가
- JWT 토큰 발급 로직 구현
- UserService 리팩토링
-->
- **AOP를 활용한 Loggin 작업**
  - 로그레벨에 따라 출력 로그를 다르게 작업하였습니다.
    - `INFO` 레벨 로그는 사용자 유형, 요청 내용, 그리고 그에 대한 결과를 간단히 파악할 수 있도록 기록합니다.
    - `DEBUG` 레벨 로그는 사용자 유형과 ID, 요청 경로, 호출된 메서드, 주고받은 값, 처리 시간(ms)까지 상세히 확인할 수 있도록 기록합니다.
  - DB 조회 시 출력되는 Hibernate의 로그를 INFO만 출력 하도록 수정하였습니다.(INFO 수준인 경우 DB 조회 관련 로그 출력 X)
    - 위 설정으로 요청 정보와 응답 정보를 간단하게 확인할 수 있습니다.
- 로그레벨이 `INFO`인 경우 다음 내용을 출력합니다.
```bash
[Request]-[`UserType`] : `HttpMethod`: `Url`: `Args`: 
[Response]-[`UserType`]  : <`200` `OK` `OK`,`SuccessResponseDTO`>
``` 
- 로그레벨이 `DEBUG`인 경우 다음 내용을 출력합니다.
```bash
[Request]-[`UserType`:`UserId`] : `HttpMethod`: `Url`: `Args`: `Headers`: 
[Before]-[`UserType`:`UserId`] : `Method`: `Args`: 
[After]-[`UserType`:`UserId`] : `Method`: `Return`: 
[Response]-[`UserType`:`UserId`] : `Method`: `time`: `returned`: <`200` `OK` `OK`,`SuccessResponseDTO`>
```
> Response의 결과값은 호출되는 Controller의 정보입니다.

- **회원메타 정보에 대한 ID 값을 INTEGER에서 LONG으로 수정하였습니다.**
- **`Auth/register` URL이 허용 URL에 누락되어 있어 반영하였습니다.**

## ✅ 테스트 결과
- **로그 레벨이 `INFO`인 경우** 
<img width="783" height="177" alt="결과" src="https://github.com/user-attachments/assets/0532f93e-de8e-4205-aafd-52163e527b21" />

- **로그 레벨이 `DEBUG`인 경우**

```bash
2025-08-04T00:14:42.692+09:00 DEBUG [http-nio-8080-exec-5] c.h.b.global.common.LoggingAspect - [Request]-[USER:1] : HttpMethod: POST Url: /api/auths/login Args: {request=UserLoginRequest(email='cod0216@nate.com', password='****')} Headers: {authorization=Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiZW1haWwiOiJjb2QwMjE2QG5hdGUuY29tIiwibmFtZSI6Iuy1nOydgOywvSIsInR5cGUiOiJVU0VSIiwidXVpZCI6ImUxYzRlZTIyLTJmYTItNDJjMi04Mzk2LTI1OTg3MmUwMTk0YSIsImlhdCI6MTc1NDA1ODUyOSwiZXhwIjoxNzU2NjUwNTI5fQ.BAXXPQzj2IK1I2uDtDvpYQKfmUp8QE1one1SFIa8nIU, content-length=58, cookie=JSESSIONID=C9153879C540CE7723BB055992632293, postman-token=22594544-ee62-4c70-8543-1340bdf38c8e, host=localhost:8080, content-type=application/json, connection=keep-alive, cache-control=no-cache, accept-encoding=gzip, deflate, br, user-agent=PostmanRuntime/7.44.1, accept=*/*}
2025-08-04T00:14:42.703+09:00 DEBUG [http-nio-8080-exec-5] c.h.b.global.common.LoggingAspect - [Before]-[USER:1] : Method: AuthService.basicLogin(..) Args: {request=UserLoginRequest(email='cod0216@nate.com', password='****')}
2025-08-04T00:14:42.851+09:00 DEBUG [http-nio-8080-exec-5] c.h.b.global.common.LoggingAspect - [Before]-[USER:1] : Method: UserService.tryUserLogin(..) Args: {login=UserLoginRequest(email='cod0216@nate.com', password='****')}
2025-08-04T00:14:43.605+09:00 DEBUG [http-nio-8080-exec-5] c.h.b.global.common.LoggingAspect - [After]-[USER:1] : Method: UserService.tryUserLogin(..) Return: UserInfoResponse(id=1, createdAt=2025-07-13T05:56:10.140148, userType=USER, email=cod0216@nate.com, name=최은창, profile=null)
2025-08-04T00:14:43.634+09:00 DEBUG [http-nio-8080-exec-5] c.h.b.global.common.LoggingAspect - [Before]-[USER:1] : Method: TokenService.generateTokens(..) Args: {user=UserInfoResponse(id=1, createdAt=2025-07-13T05:56:10.140148, userType=USER, email=cod0216@nate.com, name=최은창, profile=null)}
2025-08-04T00:14:43.700+09:00 DEBUG [http-nio-8080-exec-5] c.h.b.global.common.LoggingAspect - [After]-[USER:1] : Method: TokenService.generateTokens(..) Return: com.howaboutquestion.backend.domain.auth.dto.response.JwtTokenResponse@63b4bb87
2025-08-04T00:14:43.702+09:00 DEBUG [http-nio-8080-exec-5] c.h.b.global.common.LoggingAspect - [After]-[USER:1] : Method: AuthService.basicLogin(..) Return: UserLoginResponse(userInfoResponse=UserInfoResponse(id=1, createdAt=2025-07-13T05:56:10.140148, userType=USER, email=cod0216@nate.com, name=최은창, profile=null), jwtTokenResponse=com.howaboutquestion.backend.domain.auth.dto.response.JwtTokenResponse@63b4bb87)
2025-08-04T00:14:43.707+09:00 DEBUG [http-nio-8080-exec-5] c.h.b.global.common.LoggingAspect - [Response]-[USER:1] : Method: AuthController.login(..) time: 1043ms, returned: <200 OK OK,SuccessResponseDTO(data=UserLoginResponse(userInfoResponse=UserInfoResponse(id=1, createdAt=2025-07-13T05:56:10.140148, userType=USER, email=cod0216@nate.com, name=최은창, profile=null), jwtTokenResponse=com.howaboutquestion.backend.domain.auth.dto.response.JwtTokenResponse@63b4bb87)),[]> 
```


## 💬 리뷰 요구사항(선택)
<!-- 
리뷰어가 이해를 위해 알아야 할 점, 
혹은 후속작업이 필요한 항목,
특별히 봐주었으면 하는 부분이 있다면 작성해주세요
예: 
메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
기존 보안 로직을 변경했으므로 side effect 가능성 있음
-->
- Long값은 ERD에서 회원 ID를 unsigned int이므로 서버에서도 이를 받을 수 있게 더 큰값인 Long으로 수정하였습니다.
- 패스워드는 마스킹 처리(`****`)를 하였습니다.
- 결과를 반환할때의 로그 정보에는 토큰의 내용이 아닌 인스턴스의 주소값을 로그로 남겼습니다.

내용 확인해보시면서 궁굼하신 사항이나 로직에서 발생할 것 같은 문제들이 있으시면 편하게 말씀해주세요!

