### PR TITLE
refactor: Add separate logging logic for CustomException

### DIFF
--- a/src/main/java/com/howaboutquestion/backend/global/common/LoggingAspect.java
+++ b/src/main/java/com/howaboutquestion/backend/global/common/LoggingAspect.java
@@ -1,6 +1,7 @@
 package com.howaboutquestion.backend.global.common;
 
 import com.howaboutquestion.backend.domain.user.dto.UserDetail;
+import com.howaboutquestion.backend.global.error.CustomException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +30,7 @@ import java.util.Objects;
  * DATE              AUTHOR             NOTE<br>
  * -----------------------------------------------------------<br>
  * 25.08.03          cod0216           최초 생성 <br>
+ * 25.08.06          cod0216           의도한 Exception 로그 Info 변경 <br>
  */
 
 @Slf4j
@@ -86,7 +88,11 @@ public class LoggingAspect {
 
     @AfterThrowing(value = "onService()", throwing = "e")
     public void afterServiceThrowLog(JoinPoint joinPoint, Throwable e){
-        log.error("\n[Error]-[{}:{}] : Method: {} Args: {} Error: {} StackTrace: {}", getUserType(), getUserId(), joinPoint.getSignature().toShortString(), getParams(joinPoint), e.getMessage(), e.getStackTrace());
+        if(e instanceof CustomException ce){
+            log.info("\n[Error]-[{}:{}] : Method: {} Args: {} Error: {}", getUserType(), getUserId(), joinPoint.getSignature().toShortString(), getParams(joinPoint), e.getMessage());
+        } else {
+            log.error("\n[Error]-[{}:{}] : Method: {} Args: {} Error: {} \nStackTrace: {}", getUserType(), getUserId(), joinPoint.getSignature().toShortString(), getParams(joinPoint), e.getMessage(), e.getStackTrace());
+        }
     }
 
     /**
@@ -134,14 +140,26 @@ public class LoggingAspect {
             return result;
         } catch (Throwable e) {
             long duration = System.currentTimeMillis() - start;
-            log.error("\n[Response]-[{}:{}] : Method: {} time: {}ms Error: {} StackTrace: {}",
-                    getUserType(),
-                    getUserId(),
-                    proceed.getSignature().toShortString(),
-                    duration,
-                    e.getMessage(),
-                    e.getStackTrace()
-            );
+            if(e instanceof CustomException){
+                log.info("\n[Response]-[{}:{}] : Method: {} time: {}ms Error: {} \nStackTrace: {}",
+                        getUserType(),
+                        getUserId(),
+                        proceed.getSignature().toShortString(),
+                        duration,
+                        e.getMessage(),
+                        e.getStackTrace()
+                );
+            }else {
+                log.error("\n[Response]-[{}:{}] : Method: {} time: {}ms Error: {} \nStackTrace: {}",
+                        getUserType(),
+                        getUserId(),
+                        proceed.getSignature().toShortString(),
+                        duration,
+                        e.getMessage(),
+                        e.getStackTrace()
+                );
+            }
+
             throw e;
         }
     }


### PR DESCRIPTION
<!-- 
제목은 아래와 같은 커밋 규칙을 따르세요: 
- feat: 새로운 기능
- fix: 버그 수정
- docs: 문서 및 주석 수정
- refactor: 코드 리팩토링 (기능 변화 없음)
- style: css 변경 (로직 변화 없음)
- test: 테스트 코드 추가 또는 수정 
- build: 빌드 설정 
- chore: 기타 사소한 변경
-->


## #️⃣ 관련 이슈
<!-- 
관련된 이슈 번호를 링크하거나 언급해주세요.
예: Closes #12, #34
-->
- #14 
## 📝 작업 내용
<!-- 
이번 PR에서 작업한 내용을 항목별로 설명해주세요(이미지 첨부 가능)
예:
- 로그인 API (`POST /api/login`) 추가
- JWT 토큰 발급 로직 구현
- UserService 리팩토링
-->

- `instanceof`을 활용하여 Exception이 **의도한 예외(`CustomException`)인 경우 `info()`로 출력**하게 하였습니다.
- 의도한 예외(`CustomException`)인 경우 **서비스 수행 시 발생하는 로그 에서는 에러 메세지만 반환, StackStrace를 반환하지 않습니다.**
- 의도한 예외(`CustomException`)인 경우 마지막 **`[Response]` 로그에서 `StackTrace()`를 확인**할 수 있습니다.
  - **의도한 예외(`CustomException`) 발생** 시 다음 형식으로 출력합니다.
```bash
[Request]-[UserType] : HttpMethod: Url: Args:
[Error]-[UserType:UserId] : Method: Args: Error: 서버 내부 오류가 발생했습니다.
[Error]-[UserType:UserId] : Method: AuthService.basicLogin(..) Args: Error: e.getMessage()
[Response]-[UserType:UserId] : Method: time: 1100ms Error: e.getMessage() StackTrace: e.getStackTrace()
```
- **의도한 예외(`CustomException`)이 아닌 경우 `error()`로 출력**합니다.
- `의도한 예외`가 아닌 경우 **서비스 수행 시 발생하는 로그 에서는 에러 메세지 및 StackStrace를 반환**합니다.
  - **의도한 예외(`CustomException`)가 아닌 Exception 발생** 시 다음 형식으로 출력합니다.
```bash
[Request]-[UserType] : HttpMethod: Url: Args:
[Error]-[UserType:UserId] : Method: Args: Error: e.getMessage() StackTrace: e.getStackTrace()
[Error]-[UserType:UserId] : Method: AuthService.basicLogin(..) Args: Error: e.getMessage() StackTrace: e.getStackTrace()
[Response]-[UserType:UserId] : Method: time: 1100ms Error: e.getMessage() StackTrace: e.getStackTrace()
```


## ✅ 테스트 결과
<!-- 
직접 테스트한 내용이나 결과를 작성해주세요.
예:
- [x] 정상 로그인 시 토큰 발급 확인
- [x] 잘못된 비밀번호로 401 응답 확인
-->
**의도한 예외(`CustomException`) 발생**
- **실제 log**
<img width="840" height="260" alt="스크린샷 2025-08-06 오전 3 32 07" src="https://github.com/user-attachments/assets/2ab6d145-64ce-43b5-a691-e0ff81dc0f81" />

- **복제한 log(참고)**

```bash
2025-08-06T02:13:40.805+09:00 INFO  [http-nio-8080-exec-1] c.h.b.global.common.LoggingAspect - 
[Request]-[ANONYMOUS] : HttpMethod: POST Url: /api/auths/login Args: {request=UserLoginRequest(email='cod0216@nate.com', password='****')}
2025-08-06T02:13:41.883+09:00 INFO  [http-nio-8080-exec-1] c.h.b.global.common.LoggingAspect - 
[Error]-[ANONYMOUS:XXX] : Method: UserService.tryUserLogin(..) Args: {login=UserLoginRequest(email='cod0216@nate.com', password='****')} Error: 서버 내부 오류가 발생했습니다.
2025-08-06T02:13:41.898+09:00 INFO  [http-nio-8080-exec-1] c.h.b.global.common.LoggingAspect - 
[Error]-[ANONYMOUS:XXX] : Method: AuthService.basicLogin(..) Args: {request=UserLoginRequest(email='cod0216@nate.com', password='****')} Error: 서버 내부 오류가 발생했습니다.
2025-08-06T02:13:41.908+09:00 INFO  [http-nio-8080-exec-1] c.h.b.global.common.LoggingAspect - 
[Response]-[ANONYMOUS:XXX] : Method: AuthController.login(..) time: 1100ms Error: 서버 내부 오류가 발생했습니다. 
StackTrace: (생략...)
```

## 💬 리뷰 요구사항(선택)
<!-- 
리뷰어가 이해를 위해 알아야 할 점, 
혹은 후속작업이 필요한 항목,
특별히 봐주었으면 하는 부분이 있다면 작성해주세요
예: 
메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
기존 보안 로직을 변경했으므로 side effect 가능성 있음
-->

놓친 부분이여서 수정하였습니다! 확인해 보시고 궁굼하신 사항이나 로직에서 발생할 것 같은 문제들이 있으시면 말씀해주세요!
