### PR TITLE
refactor: prepare JPA mappings for Supabase PostgreSQL migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,6 @@ out/
 logs/
 # local docs and rules
 AGENTS.md
-README.md
 docs/
 rule/
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'com.mysql:mysql-connector-j:8.4.0'
+	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/howaboutquestion/backend/domain/book/entity/BookEntity.java
+++ b/src/main/java/com/howaboutquestion/backend/domain/book/entity/BookEntity.java
@@ -24,6 +24,7 @@ import java.util.Set;
  * DATE              AUTHOR             NOTE<br>
  * -----------------------------------------------------------<br>
  * 25.07.24          khaelim1311         최초생성<br>
+ * 26.04.30          cod0216             PostgreSQL 매핑 호환성 정리<br>
  */
 @Entity
 @Getter
@@ -39,7 +40,7 @@ public class BookEntity {
     @Id
     @EqualsAndHashCode.Include
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(nullable = false, columnDefinition = "INT UNSIGNED")
+    @Column(nullable = false)
     private Integer id;
 
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/com/howaboutquestion/backend/domain/dailyhistory/entity/DailyHistoryEntity.java
+++ b/src/main/java/com/howaboutquestion/backend/domain/dailyhistory/entity/DailyHistoryEntity.java
@@ -18,6 +18,7 @@ import java.time.LocalDate;
  * DATE              AUTHOR             NOTE<br>
  * -----------------------------------------------------------<br>
  * 25.07.24          khaelim1311         최초생성<br>
+ * 26.04.30          cod0216             PostgreSQL 매핑 호환성 정리<br>
  */
 @Entity
 @Getter
@@ -31,7 +32,7 @@ public class DailyHistoryEntity {
     @Id
     @EqualsAndHashCode.Include
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(nullable = false, columnDefinition = "INT UNSIGNED")
+    @Column(nullable = false)
     private Integer id;
 
     @Column(nullable = false)

--- a/src/main/java/com/howaboutquestion/backend/domain/exam/entity/ExamEntity.java
+++ b/src/main/java/com/howaboutquestion/backend/domain/exam/entity/ExamEntity.java
@@ -19,6 +19,7 @@ import java.time.LocalDateTime;
  * DATE              AUTHOR             NOTE<br>
  * -----------------------------------------------------------<br>
  * 25.07.24          khaelim1311         최초생성<br>
+ * 26.04.30          cod0216             PostgreSQL 매핑 호환성 정리<br>
  */
 @Entity
 @Getter
@@ -32,7 +33,7 @@ public class ExamEntity {
     @Id
     @EqualsAndHashCode.Include
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(nullable = false, columnDefinition = "INT UNSIGNED")
+    @Column(nullable = false)
     private Integer id;
 
     @CreatedDate
@@ -52,9 +53,9 @@ public class ExamEntity {
     @Column(nullable = false, precision = 5, scale = 2)
     private BigDecimal rate;
 
-    @Column(columnDefinition = "TEXT", length = 255)
+    @Column(columnDefinition = "TEXT")
     private String tag;
 
-    @Column(name = "book_id", nullable = false, columnDefinition = "INT UNSIGNED")
+    @Column(name = "book_id", nullable = false)
     private Integer bookId;
 }

--- a/src/main/java/com/howaboutquestion/backend/domain/exam/entity/ExamEntity.java
+++ b/src/main/java/com/howaboutquestion/backend/domain/exam/entity/ExamEntity.java
@@ -1,5 +1,6 @@
 package com.howaboutquestion.backend.domain.exam.entity;
 
+import com.howaboutquestion.backend.domain.book.entity.BookEntity;
 import com.howaboutquestion.backend.domain.dailyhistory.entity.DailyHistoryEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -20,6 +21,7 @@ import java.time.LocalDateTime;
  * -----------------------------------------------------------<br>
  * 25.07.24          khaelim1311         최초생성<br>
  * 26.04.30          cod0216             PostgreSQL 매핑 호환성 정리<br>
+ * 26.04.30          cod0216             book_id 연관관계 매핑으로 정리<br>
  */
 @Entity
 @Getter
@@ -56,6 +58,7 @@ public class ExamEntity {
     @Column(columnDefinition = "TEXT")
     private String tag;
 
-    @Column(name = "book_id", nullable = false)
-    private Integer bookId;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "book_id", nullable = false)
+    private BookEntity book;
 }

--- a/src/main/java/com/howaboutquestion/backend/domain/examresult/entity/ExamResultEntity.java
+++ b/src/main/java/com/howaboutquestion/backend/domain/examresult/entity/ExamResultEntity.java
@@ -16,6 +16,7 @@ import lombok.experimental.SuperBuilder;
  * DATE              AUTHOR             NOTE<br>
  * -----------------------------------------------------------<br>
  * 25.07.24          khaelim1311         최초생성<br>
+ * 26.04.30          cod0216             PostgreSQL 매핑 호환성 정리<br>
  */
 @Entity
 @Getter
@@ -30,7 +31,7 @@ public abstract class ExamResultEntity {
     @Id
     @EqualsAndHashCode.Include
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(nullable = false, columnDefinition = "INT UNSIGNED")
+    @Column(nullable = false)
     private Integer id;
 
     @Column(nullable = false)

--- a/src/main/java/com/howaboutquestion/backend/domain/examtagrate/entity/ExamTagRateEntity.java
+++ b/src/main/java/com/howaboutquestion/backend/domain/examtagrate/entity/ExamTagRateEntity.java
@@ -17,6 +17,7 @@ import java.math.RoundingMode;
  * DATE              AUTHOR             NOTE<br>
  * -----------------------------------------------------------<br>
  * 25.07.24          khaelim1311         최초생성<br>
+ * 26.04.30          cod0216             PostgreSQL 매핑 호환성 정리<br>
  */
 @Entity
 @Getter
@@ -31,7 +32,7 @@ public class ExamTagRateEntity {
     @Id
     @EqualsAndHashCode.Include
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(nullable = false, columnDefinition = "INT UNSIGNED")
+    @Column(nullable = false)
     private Integer id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/howaboutquestion/backend/domain/question/entity/QuestionEntity.java
+++ b/src/main/java/com/howaboutquestion/backend/domain/question/entity/QuestionEntity.java
@@ -25,6 +25,7 @@ import java.util.Set;
  * DATE              AUTHOR             NOTE<br>
  * -----------------------------------------------------------<br>
  * 25.07.24          khaelim1311         최초생성<br>
+ * 26.04.30          cod0216             PostgreSQL 매핑 호환성 정리<br>
  */
 @Entity
 @Getter
@@ -39,7 +40,7 @@ public abstract class QuestionEntity {
     @Id
     @EqualsAndHashCode.Include
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(nullable = false, columnDefinition = "INT UNSIGNED")
+    @Column(nullable = false)
     private Integer id;
 
     @CreatedDate

--- a/src/main/java/com/howaboutquestion/backend/domain/subscribe/entity/SubscribeEntity.java
+++ b/src/main/java/com/howaboutquestion/backend/domain/subscribe/entity/SubscribeEntity.java
@@ -16,6 +16,7 @@ import lombok.*;
  * DATE              AUTHOR             NOTE<br>
  * -----------------------------------------------------------<br>
  * 25.07.24          khaelim1311         최초생성<br>
+ * 26.04.30          cod0216             PostgreSQL 매핑 호환성 정리<br>
  */
 @Entity
 @Getter
@@ -29,7 +30,7 @@ public class SubscribeEntity {
     @Id
     @EqualsAndHashCode.Include
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(nullable = false, columnDefinition = "INT UNSIGNED")
+    @Column(nullable = false)
     private Integer id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/howaboutquestion/backend/domain/tag/entity/TagEntity.java
+++ b/src/main/java/com/howaboutquestion/backend/domain/tag/entity/TagEntity.java
@@ -13,6 +13,7 @@ import lombok.*;
  * DATE              AUTHOR             NOTE<br>
  * -----------------------------------------------------------<br>
  * 25.07.24          khaelim1311         최초생성<br>
+ * 26.04.30          cod0216             PostgreSQL 매핑 호환성 정리<br>
  */
 @Entity
 @Getter
@@ -26,7 +27,7 @@ public class TagEntity {
     @Id
     @EqualsAndHashCode.Include
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(nullable = false, columnDefinition = "BIGINT UNSIGNED")
+    @Column(nullable = false)
     private Long id;
 
     @Column(nullable = false, length = 31, unique = true)

--- a/src/main/java/com/howaboutquestion/backend/domain/usermeta/entity/UserMetaEntity.java
+++ b/src/main/java/com/howaboutquestion/backend/domain/usermeta/entity/UserMetaEntity.java
@@ -20,6 +20,7 @@ import java.time.LocalDateTime;
  * -----------------------------------------------------------<br>
  * 25.07.12          cod0216           최초생성<br>
  * 26.04.30          cod0216           PostgreSQL 매핑 호환성 정리<br>
+ * 26.04.30          cod0216           user_type 중복 컬럼 매핑 제거<br>
  */
 
 @Entity
@@ -43,8 +44,15 @@ public abstract class UserMetaEntity {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "user_type", insertable = false, updatable = false)
-    private UserType userType;
+    @Transient
+    public UserType getUserType() {
+        if (this instanceof UserEntity) {
+            return UserType.USER;
+        }
+        if (this instanceof GuestEntity) {
+            return UserType.GUEST;
+        }
+        return null;
+    }
 
 }

--- a/src/main/java/com/howaboutquestion/backend/domain/usermeta/entity/UserMetaEntity.java
+++ b/src/main/java/com/howaboutquestion/backend/domain/usermeta/entity/UserMetaEntity.java
@@ -19,6 +19,7 @@ import java.time.LocalDateTime;
  * DATE              AUTHOR             NOTE<br>
  * -----------------------------------------------------------<br>
  * 25.07.12          cod0216           최초생성<br>
+ * 26.04.30          cod0216           PostgreSQL 매핑 호환성 정리<br>
  */
 
 @Entity
@@ -33,7 +34,7 @@ import java.time.LocalDateTime;
 public abstract class UserMetaEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(nullable = false, columnDefinition = "INT UNSIGNED")
+    @Column(nullable = false)
     private Integer id;
 
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/src/test/java/com/howaboutquestion/backend/domain/usermeta/entity/UserMetaEntityTest.java
+++ b/src/test/java/com/howaboutquestion/backend/domain/usermeta/entity/UserMetaEntityTest.java
@@ -1,0 +1,33 @@
+package com.howaboutquestion.backend.domain.usermeta.entity;
+
+import com.howaboutquestion.backend.domain.guest.entity.GuestEntity;
+import com.howaboutquestion.backend.domain.user.entity.UserEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserMetaEntityTest {
+
+    @DisplayName("회원 엔티티는 USER 타입을 반환한다")
+    @Test
+    void userEntityReturnsUserType() {
+        UserEntity userEntity = UserEntity.builder()
+                .email("user@example.com")
+                .name("tester")
+                .password("encoded-password")
+                .build();
+
+        assertThat(userEntity.getUserType()).isEqualTo(UserType.USER);
+    }
+
+    @DisplayName("게스트 엔티티는 GUEST 타입을 반환한다")
+    @Test
+    void guestEntityReturnsGuestType() {
+        GuestEntity guestEntity = GuestEntity.builder()
+                .uuid("guest-uuid")
+                .build();
+
+        assertThat(guestEntity.getUserType()).isEqualTo(UserType.GUEST);
+    }
+}


### PR DESCRIPTION
<!-- 
제목은 아래와 같은 커밋 규칙을 따르세요: 
- feat: 새로운 기능
- fix: 버그 수정
- docs: 문서 및 주석 수정
- refactor: 코드 리팩토링 (기능 변화 없음)
- style: css 변경 (로직 변화 없음)
- test: 테스트 코드 추가 또는 수정 
- build: 빌드 설정 
- chore: 기타 사소한 변경
-->


## #️⃣ 관련 이슈
- #22 

## 📝 작업 내용
- MySQL 러나임 드라이버를 PostgreSQL 드라이버로 교체했습니다.
- 엔티티에서 MySQL 전용 `INT/BIGINT UNSIGNED` 매핑을 제거했습니다.
- `ExamEntity`의 TEXT + length 혼용을 정리했습니다.
- `UserMetaEntity.ser_type 중복 컬럼 매핑을 제거 했습니다.


## ✅ 테스트 결과
- Supabase와 Spring 매핑 확인했습니다..
<img width="1634" height="883" alt="image" src="https://github.com/user-attachments/assets/4674a19c-5549-4829-8b84-c744405226bb" />
- test API를 쏴서 `Response` 반응도 확인했습니다.

## 💬 리뷰 요구사항(선택)
- 500MB 한도부턴 무료 버전이여서 insert가 막힐 겁니다.
- 트래픽이 없는 경우 초반 콜드 스타트 문제가 있습니다.