### PR TITLE
feat: add exam history list and detail endpoints

### DIFF
--- a/src/main/java/com/howaboutquestion/backend/domain/exam/repository/ExamRepository.java
+++ b/src/main/java/com/howaboutquestion/backend/domain/exam/repository/ExamRepository.java
@@ -4,6 +4,8 @@ import com.howaboutquestion.backend.domain.exam.entity.ExamEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 /**
  * packageName    : com.howaboutquestion.backend.domain.exam.repository<br>
  * fileName       : ExamRepository.java<br>
@@ -14,7 +16,10 @@ import org.springframework.stereotype.Repository;
  * DATE              AUTHOR             NOTE<br>
  * -----------------------------------------------------------<br>
  * 26.05.06          eunchang          최초 생성<br>
+ * 26.05.06          eunchang          히스토리 목록 조회 쿼리 추가<br>
  */
 @Repository
 public interface ExamRepository extends JpaRepository<ExamEntity, Integer> {
+
+    List<ExamEntity> findAllByBookUserIdOrderByCreatedAtDesc(Integer userId);
 }

--- a/src/main/java/com/howaboutquestion/backend/domain/history/controller/HistoryController.java
+++ b/src/main/java/com/howaboutquestion/backend/domain/history/controller/HistoryController.java
@@ -1,0 +1,48 @@
+package com.howaboutquestion.backend.domain.history.controller;
+
+import com.howaboutquestion.backend.domain.history.service.HistoryComplexService;
+import com.howaboutquestion.backend.domain.user.dto.UserDetail;
+import com.howaboutquestion.backend.global.util.ResponseUtility;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * packageName    : com.howaboutquestion.backend.domain.history.controller<br>
+ * fileName       : HistoryController.java<br>
+ * author         : eunchang<br>
+ * date           : 2026.05.06<br>
+ * description    : 시험 히스토리 요청을 처리하는 Controller 클래스입니다.<br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 26.05.06          eunchang          최초 생성<br>
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/history/exams")
+public class HistoryController {
+
+    private final HistoryComplexService historyComplexService;
+
+    @GetMapping
+    public ResponseEntity<?> getExamHistories(@AuthenticationPrincipal UserDetail userDetail) {
+        return ResponseUtility.success(
+                historyComplexService.getExamHistories(Long.parseLong(userDetail.getUserId()))
+        );
+    }
+
+    @GetMapping("/{examId}")
+    public ResponseEntity<?> getExamHistoryDetail(
+            @AuthenticationPrincipal UserDetail userDetail,
+            @PathVariable Integer examId
+    ) {
+        return ResponseUtility.success(
+                historyComplexService.getExamHistoryDetail(Long.parseLong(userDetail.getUserId()), examId)
+        );
+    }
+}

--- a/src/main/java/com/howaboutquestion/backend/domain/history/dto/response/ExamHistorySummaryResponse.java
+++ b/src/main/java/com/howaboutquestion/backend/domain/history/dto/response/ExamHistorySummaryResponse.java
@@ -1,0 +1,36 @@
+package com.howaboutquestion.backend.domain.history.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * packageName    : com.howaboutquestion.backend.domain.history.dto.response<br>
+ * fileName       : ExamHistorySummaryResponse.java<br>
+ * author         : eunchang<br>
+ * date           : 2026.05.06<br>
+ * description    : 시험 히스토리 목록 요약 응답 DTO 입니다.<br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 26.05.06          eunchang          최초 생성<br>
+ */
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ExamHistorySummaryResponse {
+
+    private Integer examId;
+    private Integer bookId;
+    private String bookTitle;
+    private LocalDateTime createdAt;
+    private Integer correctQuestion;
+    private Integer solvedQuestion;
+    private BigDecimal rate;
+}

--- a/src/main/java/com/howaboutquestion/backend/domain/history/service/HistoryComplexService.java
+++ b/src/main/java/com/howaboutquestion/backend/domain/history/service/HistoryComplexService.java
@@ -1,0 +1,84 @@
+package com.howaboutquestion.backend.domain.history.service;
+
+import com.howaboutquestion.backend.domain.exam.dto.mapper.ExamMapper;
+import com.howaboutquestion.backend.domain.exam.dto.response.ExamResultItemResponse;
+import com.howaboutquestion.backend.domain.exam.dto.response.ExamResultResponse;
+import com.howaboutquestion.backend.domain.exam.entity.ExamEntity;
+import com.howaboutquestion.backend.domain.examresult.service.ExamResultService;
+import com.howaboutquestion.backend.domain.history.dto.response.ExamHistorySummaryResponse;
+import com.howaboutquestion.backend.global.common.StatusCode;
+import com.howaboutquestion.backend.global.error.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * packageName    : com.howaboutquestion.backend.domain.history.service<br>
+ * fileName       : HistoryComplexService.java<br>
+ * author         : eunchang<br>
+ * date           : 2026.05.06<br>
+ * description    : 시험 히스토리 유스케이스를 조합하는 ComplexService 클래스입니다.<br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 26.05.06          eunchang          최초 생성<br>
+ */
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class HistoryComplexService {
+
+    private final HistoryService historyService;
+    private final ExamResultService examResultService;
+    private final ExamMapper examMapper;
+
+    public List<ExamHistorySummaryResponse> getExamHistories(Long userId) {
+        return historyService.getExamHistories(userId)
+                .stream()
+                .map(this::toSummaryResponse)
+                .toList();
+    }
+
+    public ExamResultResponse getExamHistoryDetail(Long userId, Integer examId) {
+        ExamEntity exam = findOwnedExam(userId, examId);
+        List<ExamResultItemResponse> resultItems = examResultService.getExamResults(examId)
+                .stream()
+                .map(examMapper::mapToExamResultItemResponse)
+                .toList();
+
+        return ExamResultResponse.builder()
+                .examId(exam.getId())
+                .bookId(exam.getBook().getId())
+                .bookTitle(exam.getBook().getTitle())
+                .startedAt(exam.getCreatedAt())
+                .correctQuestion(exam.getCorrectQuestion())
+                .solvedQuestion(exam.getSolvedQuestion())
+                .rate(exam.getRate())
+                .results(resultItems)
+                .build();
+    }
+
+    public ExamEntity findOwnedExam(Long userId, Integer examId) {
+        ExamEntity exam = historyService.findExamById(examId);
+
+        if (!exam.getBook().getUser().getId().equals(Math.toIntExact(userId))) {
+            throw new CustomException(StatusCode.NO_USER_PERMISSION);
+        }
+
+        return exam;
+    }
+
+    private ExamHistorySummaryResponse toSummaryResponse(ExamEntity exam) {
+        return ExamHistorySummaryResponse.builder()
+                .examId(exam.getId())
+                .bookId(exam.getBook().getId())
+                .bookTitle(exam.getBook().getTitle())
+                .createdAt(exam.getCreatedAt())
+                .correctQuestion(exam.getCorrectQuestion())
+                .solvedQuestion(exam.getSolvedQuestion())
+                .rate(exam.getRate())
+                .build();
+    }
+}

--- a/src/main/java/com/howaboutquestion/backend/domain/history/service/HistoryService.java
+++ b/src/main/java/com/howaboutquestion/backend/domain/history/service/HistoryService.java
@@ -1,0 +1,39 @@
+package com.howaboutquestion.backend.domain.history.service;
+
+import com.howaboutquestion.backend.domain.exam.entity.ExamEntity;
+import com.howaboutquestion.backend.domain.exam.repository.ExamRepository;
+import com.howaboutquestion.backend.global.common.StatusCode;
+import com.howaboutquestion.backend.global.error.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * packageName    : com.howaboutquestion.backend.domain.history.service<br>
+ * fileName       : HistoryService.java<br>
+ * author         : eunchang<br>
+ * date           : 2026.05.06<br>
+ * description    : 히스토리 조회 도메인 서비스 로직을 수행하는 클래스입니다.<br>
+ * ===========================================================<br>
+ * DATE              AUTHOR             NOTE<br>
+ * -----------------------------------------------------------<br>
+ * 26.05.06          eunchang          최초 생성<br>
+ */
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class HistoryService {
+
+    private final ExamRepository examRepository;
+
+    public List<ExamEntity> getExamHistories(Long userId) {
+        return examRepository.findAllByBookUserIdOrderByCreatedAtDesc(Math.toIntExact(userId));
+    }
+
+    public ExamEntity findExamById(Integer examId) {
+        return examRepository.findById(examId)
+                .orElseThrow(() -> new CustomException(StatusCode.RESOURCE_NOT_FOUND));
+    }
+}

--- a/src/test/java/com/howaboutquestion/backend/domain/history/service/HistoryComplexServiceTest.java
+++ b/src/test/java/com/howaboutquestion/backend/domain/history/service/HistoryComplexServiceTest.java
@@ -1,0 +1,161 @@
+package com.howaboutquestion.backend.domain.history.service;
+
+import com.howaboutquestion.backend.domain.book.entity.BookEntity;
+import com.howaboutquestion.backend.domain.book.entity.Visibility;
+import com.howaboutquestion.backend.domain.exam.dto.mapper.ExamMapper;
+import com.howaboutquestion.backend.domain.exam.dto.response.ExamResultItemResponse;
+import com.howaboutquestion.backend.domain.exam.dto.response.ExamResultResponse;
+import com.howaboutquestion.backend.domain.exam.entity.ExamEntity;
+import com.howaboutquestion.backend.domain.examresult.entity.ExamMultiple;
+import com.howaboutquestion.backend.domain.examresult.entity.ExamResultEntity;
+import com.howaboutquestion.backend.domain.examresult.service.ExamResultService;
+import com.howaboutquestion.backend.domain.history.dto.response.ExamHistorySummaryResponse;
+import com.howaboutquestion.backend.domain.user.entity.UserEntity;
+import com.howaboutquestion.backend.global.common.StatusCode;
+import com.howaboutquestion.backend.global.error.CustomException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class HistoryComplexServiceTest {
+
+    @Mock
+    private HistoryService historyService;
+
+    @Mock
+    private ExamResultService examResultService;
+
+    @Mock
+    private ExamMapper examMapper;
+
+    @InjectMocks
+    private HistoryComplexService historyComplexService;
+
+    @DisplayName("시험 히스토리 목록 조회에 성공한다")
+    @Test
+    void getExamHistoriesReturnsSummaryList() {
+        UserEntity user = createUserEntity(1);
+        ExamEntity exam = createExamEntity(user, 100);
+
+        given(historyService.getExamHistories(1L)).willReturn(List.of(exam));
+
+        List<ExamHistorySummaryResponse> results = historyComplexService.getExamHistories(1L);
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getExamId()).isEqualTo(100);
+        assertThat(results.get(0).getBookTitle()).isEqualTo("자료구조");
+    }
+
+    @DisplayName("시험 히스토리 상세 조회에 성공한다")
+    @Test
+    void getExamHistoryDetailReturnsResultResponse() {
+        UserEntity user = createUserEntity(1);
+        ExamEntity exam = createExamEntity(user, 100);
+        ExamResultEntity resultEntity = createExamResultEntity(exam);
+        ExamResultItemResponse resultItemResponse = createExamResultItemResponse();
+
+        given(historyService.findExamById(100)).willReturn(exam);
+        given(examResultService.getExamResults(100)).willReturn(List.of(resultEntity));
+        given(examMapper.mapToExamResultItemResponse(resultEntity)).willReturn(resultItemResponse);
+
+        ExamResultResponse response = historyComplexService.getExamHistoryDetail(1L, 100);
+
+        assertThat(response.getExamId()).isEqualTo(100);
+        assertThat(response.getResults()).containsExactly(resultItemResponse);
+    }
+
+    @DisplayName("타인의 시험 히스토리 상세 조회는 권한 예외를 반환한다")
+    @Test
+    void getExamHistoryDetailThrowsWhenNotOwner() {
+        UserEntity otherUser = createUserEntity(2);
+        ExamEntity exam = createExamEntity(otherUser, 100);
+
+        given(historyService.findExamById(100)).willReturn(exam);
+
+        assertThatThrownBy(() -> historyComplexService.getExamHistoryDetail(1L, 100))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(StatusCode.NO_USER_PERMISSION);
+    }
+
+    private UserEntity createUserEntity(int id) {
+        UserEntity user = UserEntity.builder()
+                .email("user@example.com")
+                .name("tester")
+                .password("encoded-password")
+                .profile("profile.png")
+                .build();
+        user.setId(id);
+        return user;
+    }
+
+    private ExamEntity createExamEntity(UserEntity user, Integer examId) {
+        BookEntity book = BookEntity.builder()
+                .id(10)
+                .user(user)
+                .title("자료구조")
+                .content("기본 정리")
+                .visibility(Visibility.PRIVATE)
+                .checkFavorite(false)
+                .createdAt(LocalDateTime.of(2026, 5, 6, 0, 0))
+                .updatedAt(LocalDateTime.of(2026, 5, 6, 1, 0))
+                .build();
+
+        return ExamEntity.builder()
+                .id(examId)
+                .createdAt(LocalDateTime.of(2026, 5, 6, 10, 0))
+                .book(book)
+                .correctQuestion(1)
+                .solvedQuestion(2)
+                .rate(BigDecimal.valueOf(50.00))
+                .build();
+    }
+
+    private ExamResultEntity createExamResultEntity(ExamEntity exam) {
+        return ExamMultiple.builder()
+                .id(200)
+                .type(com.howaboutquestion.backend.domain.question.entity.QuestionType.MULTIPLE)
+                .title("객관식 문제")
+                .description("설명")
+                .picture("image.png")
+                .exam(exam)
+                .checkCorrect(true)
+                .tag(null)
+                .selectOne("1번")
+                .selectTwo("2번")
+                .selectThree("3번")
+                .selectFour("4번")
+                .selectFive("5번")
+                .answer(com.howaboutquestion.backend.domain.question.entity.MultipleAnswer.ONE)
+                .build();
+    }
+
+    private ExamResultItemResponse createExamResultItemResponse() {
+        return ExamResultItemResponse.builder()
+                .examResultId(200)
+                .type(com.howaboutquestion.backend.domain.question.entity.QuestionType.MULTIPLE)
+                .title("객관식 문제")
+                .description("설명")
+                .picture("image.png")
+                .checkCorrect(true)
+                .selectOne("1번")
+                .selectTwo("2번")
+                .selectThree("3번")
+                .selectFour("4번")
+                .selectFive("5번")
+                .multipleAnswer(com.howaboutquestion.backend.domain.question.entity.MultipleAnswer.ONE)
+                .build();
+    }
+}


### PR DESCRIPTION
<!-- 
제목은 아래와 같은 커밋 규칙을 따르세요: 
- feat: 새로운 기능
- fix: 버그 수정
- docs: 문서 및 주석 수정
- refactor: 코드 리팩토링 (기능 변화 없음)
- style: css 변경 (로직 변화 없음)
- test: 테스트 코드 추가 또는 수정 
- build: 빌드 설정 
- chore: 기타 사소한 변경
-->


## #️⃣ 관련 이슈
- #40 

## 📝 작업 내용
- 시험 히스토리 목록 조회 API를 추가했습니다.
- 시험 히스토리 상세 조회 API를 추가했습니다.
- 시험 기록 목록/상세 조회 service와 endpoint를 구현했습니다.

## ✅ 테스트 결과
- 1차 mvp 이후 한꺼번에 하겠습니다.

## 💬 리뷰 요구사항(선택)
- 사전 협의 했던 내용이여서 API 명세서에 반영하겠습니다.
